### PR TITLE
Support more models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # tools
 .idea
+.vscode
 
 # local env
 local.env.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "github-markdown-css": "^5.5.1",
         "hast": "^1.0.0",
         "highlight.js": "^11.9.0",
-        "i18next": "^23.11.2",
+        "i18next": "^23.11.3",
         "i18next-browser-languagedetector": "^7.2.1",
         "i18next-http-backend": "^2.5.1",
         "postcss": "^8.4.38",
@@ -7181,9 +7181,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.11.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.2.tgz",
-      "integrity": "sha512-qMBm7+qT8jdpmmDw/kQD16VpmkL9BdL+XNAK5MNbNFaf1iQQq35ZbPrSlqmnNPOSUY4m342+c0t0evinF5l7sA==",
+      "version": "23.11.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.3.tgz",
+      "integrity": "sha512-Pq/aSKowir7JM0rj+Wa23Kb6KKDUGno/HjG+wRQu0PxoTbpQ4N89MAT0rFGvXmLkRLNMb1BbBOKGozl01dabzg==",
       "funding": [
         {
           "type": "individual",
@@ -20954,9 +20954,9 @@
       "peer": true
     },
     "i18next": {
-      "version": "23.11.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.2.tgz",
-      "integrity": "sha512-qMBm7+qT8jdpmmDw/kQD16VpmkL9BdL+XNAK5MNbNFaf1iQQq35ZbPrSlqmnNPOSUY4m342+c0t0evinF5l7sA==",
+      "version": "23.11.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.3.tgz",
+      "integrity": "sha512-Pq/aSKowir7JM0rj+Wa23Kb6KKDUGno/HjG+wRQu0PxoTbpQ4N89MAT0rFGvXmLkRLNMb1BbBOKGozl01dabzg==",
       "requires": {
         "@babel/runtime": "^7.23.2"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "github-markdown-css": "^5.5.1",
     "hast": "^1.0.0",
     "highlight.js": "^11.9.0",
-    "i18next": "^23.11.2",
+    "i18next": "^23.11.3",
     "i18next-browser-languagedetector": "^7.2.1",
     "i18next-http-backend": "^2.5.1",
     "postcss": "^8.4.38",

--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -1,4 +1,4 @@
-export const OPENAI_ENDPOINT = 'https://api.openai.com';
-export const TTS_ENDPOINT = `${OPENAI_ENDPOINT}/v1/audio/speech`;
-export const CHAT_COMPLETIONS_ENDPOINT = `${OPENAI_ENDPOINT}/v1/chat/completions`;
-export const MODELS_ENDPOINT = `${OPENAI_ENDPOINT}/v1/models`;
+export const OPENAI_ENDPOINT = 'https://api.deepinfra.com';
+export const TTS_ENDPOINT = `${OPENAI_ENDPOINT}/v1/openai/audio/speech`;
+export const CHAT_COMPLETIONS_ENDPOINT = `${OPENAI_ENDPOINT}/v1/openai/chat/completions`;
+export const MODELS_ENDPOINT = `${OPENAI_ENDPOINT}/v1/openai/models`;

--- a/src/constants/appConstants.ts
+++ b/src/constants/appConstants.ts
@@ -7,7 +7,7 @@ export const MAX_ROWS = 20;
 export const MAX_TITLE_LENGTH = 128;
 
 export const CHAT_STREAM_DEBOUNCE_TIME = 250;
-export const DEFAULT_MODEL = 'gpt-4-turbo';
+export const DEFAULT_MODEL = 'meta-llama/Meta-Llama-3-70B-Instruct';
 export const DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
 
 

--- a/src/env.json
+++ b/src/env.json
@@ -1,5 +1,5 @@
 {
   "openapi_key": "your-api-key-here",
-  "default_model": "gpt-3.5-turbo",
+  "default_model": "meta-llama/Meta-Llama-3-70B-Instruct",
   "default_system_prompt": "You are a helpful assistant."
 }

--- a/src/models/ChatCompletion.ts
+++ b/src/models/ChatCompletion.ts
@@ -17,7 +17,7 @@ export interface ChatMessagePart {
 
 export interface ChatCompletionMessage {
   role: Role,
-  content: ChatMessagePart[];
+  content: ChatMessagePart[] | string;
 }
 
 export interface ChatCompletionRequest {

--- a/src/service/ChatService.ts
+++ b/src/service/ChatService.ts
@@ -54,11 +54,18 @@ export class ChatService {
             });
           }
         });
+        return {
+          role: message.role,
+          content: contentParts,
+        };
       }
-      return {
-        role: message.role,
-        content: contentParts,
-      };
+      else {
+        return {
+          role: message.role,
+          content: message.content,
+        };
+      }
+      
     });
   }
 
@@ -317,7 +324,7 @@ export class ChatService {
           const models: OpenAIModel[] = data.data;
           // Filter, enrich with contextWindow from the imported constant, and sort
           return models
-              .filter(model => model.id.startsWith("gpt-"))
+              .filter(model => model.id)
               .map(model => {
                 const details = modelDetails[model.id] || {
                   contextWindowSize: 0,


### PR DESCRIPTION
Deep infra, and maybe some other model providers dont support ChatMessagePart[] as part of the message sent via http request, rather they work with only Strings. We can default to just sending the message.content and only try to send a ChatMessagePart[] if the model supports it.

I also changed it so that all the models supported by the api are listed instead of just gpt ones.

The changes to src/constants/appConstants.ts and src/constants/apiEndpoints.ts are just to demostrate the usage of another api, and maybe you can test with that if you set up a free account.

cheers!


![image](https://github.com/elebitzero/openai-react-chat/assets/53794934/82129931-5a9a-41a4-93a9-7bf33918370d)
